### PR TITLE
Refresh GoDoc upon tag push

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,7 @@ name: CI
 on:
   push:
     branches: [ "master" ]
+    tags: [ "v*.*.*" ]
   pull_request:
     branches: [ "master" ]
 
@@ -26,3 +27,7 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name: Refresh version on go.dev
+      if: ${{ github.event_name == 'pull_request' && github.ref_type == 'tag' }}
+      run: GOPROXY=proxy.golang.org go list -m github.com/PlanitarInc/slc@${GITHUB_REF_NAME}


### PR DESCRIPTION
The PR refresh package's documentation on https://go.dev/ upon a push to a tag. The step for refreshing the package index is taken from https://go.dev/doc/modules/publishing.