### PR TITLE
Fix the CI rule for refreshing GoDoc upon tag push

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,5 +29,8 @@ jobs:
       run: go test -v ./...
 
     - name: Refresh version on go.dev
-      if: ${{ github.event_name == 'pull_request' && github.ref_type == 'tag' }}
-      run: GOPROXY=proxy.golang.org go list -m github.com/PlanitarInc/slc@${GITHUB_REF_NAME}
+      if: github.event_name == 'push' && github.ref_type == 'tag'
+      env:
+        GOPROXY: proxy.golang.org 
+        PACKAGE_VERSION: ${{ github.ref_name }}
+      run: go list -m github.com/PlanitarInc/slc@${PACKAGE_VERSION}


### PR DESCRIPTION
A fixup for https://github.com/PlanitarInc/slc/pull/1