### PR TITLE
Update api docs

### DIFF
--- a/slc.go
+++ b/slc.go
@@ -2,9 +2,9 @@ package slc
 
 // Includes detects if the given slice includes the given element.
 // The type of the slice elements must be comparable.
-func Includes[S ~[]E, E comparable](slice S, elem E) bool {
-	for i := range slice {
-		if slice[i] == elem {
+func Includes[S ~[]E, E comparable](s S, e E) bool {
+	for i := range s {
+		if s[i] == e {
 			return true
 		}
 	}
@@ -13,9 +13,9 @@ func Includes[S ~[]E, E comparable](slice S, elem E) bool {
 }
 
 // IncludesFunc detects if the given slice includes an element satisfying the predicate.
-func IncludesFunc[S ~[]E, E any](slice S, predicateFn func(elem E) bool) bool {
-	for i := range slice {
-		if predicateFn(slice[i]) {
+func IncludesFunc[S ~[]E, E any](s S, predicateFn func(e E) bool) bool {
+	for i := range s {
+		if predicateFn(s[i]) {
 			return true
 		}
 	}
@@ -26,9 +26,9 @@ func IncludesFunc[S ~[]E, E any](slice S, predicateFn func(elem E) bool) bool {
 // Index returns the index of the given element in the slice. The function
 // returns -1 if the element is not found.
 // The type of the slice elements must be comparable.
-func Index[S ~[]E, E comparable](slice S, elem E) int {
-	for i := range slice {
-		if slice[i] == elem {
+func Index[S ~[]E, E comparable](s S, e E) int {
+	for i := range s {
+		if s[i] == e {
 			return i
 		}
 	}
@@ -38,9 +38,9 @@ func Index[S ~[]E, E comparable](slice S, elem E) int {
 
 // IndexFunc returns the index of an element satisfying the predicate. The function
 // returns -1 if such element is not found.
-func IndexFunc[S ~[]E, E any](slice S, predicateFn func(elem E) bool) int {
-	for i := range slice {
-		if predicateFn(slice[i]) {
+func IndexFunc[S ~[]E, E any](s S, predicateFn func(e E) bool) int {
+	for i := range s {
+		if predicateFn(s[i]) {
 			return i
 		}
 	}
@@ -49,9 +49,9 @@ func IndexFunc[S ~[]E, E any](slice S, predicateFn func(elem E) bool) int {
 }
 
 // Every detects if all elements satisfy the given predicate.
-func Every[S ~[]E, E any](slice S, predicateFn func(elem E) bool) bool {
-	for i := range slice {
-		if !predicateFn(slice[i]) {
+func Every[S ~[]E, E any](s S, predicateFn func(e E) bool) bool {
+	for i := range s {
+		if !predicateFn(s[i]) {
 			return false
 		}
 	}
@@ -61,9 +61,9 @@ func Every[S ~[]E, E any](slice S, predicateFn func(elem E) bool) bool {
 
 // Some detects if there is at least one element satisfying the given
 // predicate.
-func Some[S ~[]E, E any](slice S, predicateFn func(elem E) bool) bool {
-	for i := range slice {
-		if predicateFn(slice[i]) {
+func Some[S ~[]E, E any](s S, predicateFn func(e E) bool) bool {
+	for i := range s {
+		if predicateFn(s[i]) {
 			return true
 		}
 	}
@@ -73,10 +73,10 @@ func Some[S ~[]E, E any](slice S, predicateFn func(elem E) bool) bool {
 
 // Find returns the first element in the given slice satisfying the predicate.
 // A zero value is returned if no element is found.
-func Find[S ~[]E, E any](slice S, predicateFn func(elem E) bool) E {
-	for i := range slice {
-		if predicateFn(slice[i]) {
-			return slice[i]
+func Find[S ~[]E, E any](s S, predicateFn func(e E) bool) E {
+	for i := range s {
+		if predicateFn(s[i]) {
+			return s[i]
 		}
 	}
 
@@ -86,10 +86,10 @@ func Find[S ~[]E, E any](slice S, predicateFn func(elem E) bool) E {
 
 // FindPtr returns a pointer to the first element in the given slice satisfying
 // the predicate. Nil is returned if no element is found.
-func FindPtr[S ~[]E, E any](slice S, predicateFn func(elem E) bool) *E {
-	for i := range slice {
-		if predicateFn(slice[i]) {
-			return &slice[i]
+func FindPtr[S ~[]E, E any](s S, predicateFn func(e E) bool) *E {
+	for i := range s {
+		if predicateFn(s[i]) {
+			return &s[i]
 		}
 	}
 
@@ -98,20 +98,20 @@ func FindPtr[S ~[]E, E any](slice S, predicateFn func(elem E) bool) *E {
 
 // Map returns a copy of the given slice containing all elements transformed by
 // the given function.
-func Map[S1 ~[]E1, E1, E2 any](slice S1, transformFn func(elem E1) E2) []E2 {
+func Map[S1 ~[]E1, E1, E2 any](s S1, transformFn func(e E1) E2) []E2 {
 	var res []E2
-	for i := range slice {
-		res = append(res, transformFn(slice[i]))
+	for i := range s {
+		res = append(res, transformFn(s[i]))
 	}
 	return res
 }
 
 // Reduce returns the result of applying the given function to each element of
 // the given slice. The function is applied left-to-right.
-func Reduce[S ~[]E, E, T any](slice S, accumulateFn func(acc T, elem E) T) T {
+func Reduce[S ~[]E, E, T any](s S, accumulateFn func(acc T, e E) T) T {
 	var res T
-	for i := range slice {
-		res = accumulateFn(res, slice[i])
+	for i := range s {
+		res = accumulateFn(res, s[i])
 	}
 	return res
 }
@@ -120,11 +120,11 @@ func Reduce[S ~[]E, E, T any](slice S, accumulateFn func(acc T, elem E) T) T {
 // the given predicate.
 //
 // This function is the opposite of FilterOut().
-func Filter[S ~[]E, E any](slice S, predicateFn func(elem E) bool) S {
+func Filter[S ~[]E, E any](s S, predicateFn func(e E) bool) S {
 	var res S
-	for i := range slice {
-		if predicateFn(slice[i]) {
-			res = append(res, slice[i])
+	for i := range s {
+		if predicateFn(s[i]) {
+			res = append(res, s[i])
 		}
 	}
 	return res
@@ -134,11 +134,11 @@ func Filter[S ~[]E, E any](slice S, predicateFn func(elem E) bool) S {
 // satisfying the given predicate.
 //
 // This function is the opposite of Filter().
-func FilterOut[S ~[]E, E any](slice S, predicateFn func(elem E) bool) S {
+func FilterOut[S ~[]E, E any](s S, predicateFn func(e E) bool) S {
 	var res S
-	for i := range slice {
-		if !predicateFn(slice[i]) {
-			res = append(res, slice[i])
+	for i := range s {
+		if !predicateFn(s[i]) {
+			res = append(res, s[i])
 		}
 	}
 	return res
@@ -146,11 +146,11 @@ func FilterOut[S ~[]E, E any](slice S, predicateFn func(elem E) bool) S {
 
 // Uniq returns a copy of the given slice containing all unique elements.
 // The type of the slice elements must be comparable.
-func Uniq[S ~[]E, E comparable](slice S) S {
+func Uniq[S ~[]E, E comparable](s S) S {
 	var res S
-	for i := range slice {
-		if !Includes(res, slice[i]) {
-			res = append(res, slice[i])
+	for i := range s {
+		if !Includes(res, s[i]) {
+			res = append(res, s[i])
 		}
 	}
 	return res
@@ -158,11 +158,11 @@ func Uniq[S ~[]E, E comparable](slice S) S {
 
 // Uniq returns a copy of the given slice containing all unique elements.
 // The type of the slice elements must be comparable.
-func UniqFunc[S ~[]E, E any](slice S, equalsFn func(n, m E) bool) S {
+func UniqFunc[S ~[]E, E any](s S, equalsFn func(n, m E) bool) S {
 	var res S
-	for i := range slice {
-		if !IncludesFunc(res, func(elem E) bool { return equalsFn(slice[i], elem) }) {
-			res = append(res, slice[i])
+	for i := range s {
+		if !IncludesFunc(res, func(e E) bool { return equalsFn(s[i], e) }) {
+			res = append(res, s[i])
 		}
 	}
 	return res
@@ -170,9 +170,9 @@ func UniqFunc[S ~[]E, E any](slice S, equalsFn func(n, m E) bool) S {
 
 // Overlap returns true if two slices have at least one common element.
 // The type of the slice elements must be comparable.
-func Overlap[S ~[]E, E comparable](a, b S) bool {
-	for i := range a {
-		if Includes(b, a[i]) {
+func Overlap[S ~[]E, E comparable](s1, s2 S) bool {
+	for i := range s1 {
+		if Includes(s2, s1[i]) {
 			return true
 		}
 	}
@@ -183,13 +183,13 @@ func Overlap[S ~[]E, E comparable](a, b S) bool {
 // OverlapFunc returns true if two slices have at least one common element.
 // The elements are compared using the given function, equalsFn.
 func OverlapFunc[S1 ~[]E1, S2 ~[]E2, E1, E2 any](
-	a S1,
-	b S2,
+	s1 S1,
+	s2 S2,
 	equalsFn func(e1 E1, e2 E2) bool,
 ) bool {
-	for i := range a {
-		for j := range b {
-			if equalsFn(a[i], b[j]) {
+	for i := range s1 {
+		for j := range s2 {
+			if equalsFn(s1[i], s2[j]) {
 				return true
 			}
 		}
@@ -200,11 +200,11 @@ func OverlapFunc[S1 ~[]E1, S2 ~[]E2, E1, E2 any](
 
 // Intersect returns the intersection of two slices.
 // The type of the slice elements must be comparable.
-func Intersect[S ~[]E, E comparable](a, b S) S {
+func Intersect[S ~[]E, E comparable](s1, s2 S) S {
 	var res S
-	for i := range a {
-		if !Includes(res, a[i]) && Includes(b, a[i]) {
-			res = append(res, a[i])
+	for i := range s1 {
+		if !Includes(res, s1[i]) && Includes(s2, s1[i]) {
+			res = append(res, s1[i])
 		}
 	}
 	return res
@@ -213,21 +213,21 @@ func Intersect[S ~[]E, E comparable](a, b S) S {
 // Intersect returns the intersection of two slices.
 // The elements are compared using the given function, equalsFn.
 func IntersectFunc[S1 ~[]E1, S2 ~[]E2, E1 comparable, E2 any](
-	a S1,
-	b S2,
+	s1 S1,
+	s2 S2,
 	equalsFn func(e1 E1, e2 E2) bool,
 ) S1 {
 	var res S1
 
 OuterLoop:
-	for i := range a {
-		if Includes(res, a[i]) {
+	for i := range s1 {
+		if Includes(res, s1[i]) {
 			continue
 		}
 
-		for j := range b {
-			if equalsFn(a[i], b[j]) {
-				res = append(res, a[i])
+		for j := range s2 {
+			if equalsFn(s1[i], s2[j]) {
+				res = append(res, s1[i])
 				continue OuterLoop
 			}
 		}
@@ -236,29 +236,29 @@ OuterLoop:
 	return res
 }
 
-// Diff returns the difference between the given slices: a - b.
+// Diff returns the difference between the given slices: s1 - s2.
 // The type of the slice elements must be comparable.
-func Diff[S ~[]E, E comparable](a, b S) S {
+func Diff[S ~[]E, E comparable](s1, s2 S) S {
 	var res S
-	for i := range a {
-		if !Includes(b, a[i]) {
-			res = append(res, a[i])
+	for i := range s1 {
+		if !Includes(s2, s1[i]) {
+			res = append(res, s1[i])
 		}
 	}
 	return res
 }
 
-// DiffFunc returns the difference between the given slices: a - b.
+// DiffFunc returns the difference between the given slices: s1 - s2.
 // The elements are compared using the given function, equalsFn.
 func DiffFunc[S1 ~[]E1, S2 ~[]E2, E1, E2 any](
-	a S1,
-	b S2,
+	s1 S1,
+	s2 S2,
 	equalsFn func(e1 E1, e2 E2) bool,
 ) S1 {
 	var res S1
-	for i := range a {
-		if !IncludesFunc(b, func(elem E2) bool { return equalsFn(a[i], elem) }) {
-			res = append(res, a[i])
+	for i := range s1 {
+		if !IncludesFunc(s2, func(e E2) bool { return equalsFn(s1[i], e) }) {
+			res = append(res, s1[i])
 		}
 	}
 	return res

--- a/slc.go
+++ b/slc.go
@@ -168,7 +168,8 @@ func UniqFunc[S ~[]E, E any](s S, equalsFn func(n, m E) bool) S {
 	return res
 }
 
-// Overlap returns true if two slices have at least one common element.
+// Overlap returns true if two slices have at least one common element:
+// s1 ∩ s2 ≠ ∅.
 // The type of the slice elements must be comparable.
 func Overlap[S ~[]E, E comparable](s1, s2 S) bool {
 	for i := range s1 {
@@ -180,7 +181,8 @@ func Overlap[S ~[]E, E comparable](s1, s2 S) bool {
 	return false
 }
 
-// OverlapFunc returns true if two slices have at least one common element.
+// OverlapFunc returns true if two slices have at least one common element:
+// s1 ∩ s2 ≠ ∅.
 // The elements are compared using the given function, equalsFn.
 func OverlapFunc[S1 ~[]E1, S2 ~[]E2, E1, E2 any](
 	s1 S1,
@@ -198,7 +200,7 @@ func OverlapFunc[S1 ~[]E1, S2 ~[]E2, E1, E2 any](
 	return false
 }
 
-// Intersect returns the intersection of two slices.
+// Intersect returns the intersection of two slices: s1 ∩ s2.
 // The type of the slice elements must be comparable.
 func Intersect[S ~[]E, E comparable](s1, s2 S) S {
 	var res S
@@ -210,7 +212,7 @@ func Intersect[S ~[]E, E comparable](s1, s2 S) S {
 	return res
 }
 
-// Intersect returns the intersection of two slices.
+// Intersect returns the intersection of two slices: s1 ∩ s2.
 // The elements are compared using the given function, equalsFn.
 func IntersectFunc[S1 ~[]E1, S2 ~[]E2, E1 comparable, E2 any](
 	s1 S1,


### PR DESCRIPTION
The PR tries to make the API docs in https://pkg.go.dev/github.com/PlanitarInc/slc more consistent:
- Update API to have consistent naming for arguments
   The rules are:
   - use `s` for slice argumnets
   - use `e` for element arguments
   - append index to argument names if there are multiple of them;
      e.g. `s1`/`s2` or `e1`/`e2`
- Add missing math meaning for more functions: `Overlap()` and `Intersect()`